### PR TITLE
Serve Gang of Three font locally

### DIFF
--- a/public/fonts/GangOfThree.ttf
+++ b/public/fonts/GangOfThree.ttf
@@ -1,0 +1,1 @@
+Placeholder for Gang Of Three font (.ttf)

--- a/public/fonts/GangOfThree.woff2
+++ b/public/fonts/GangOfThree.woff2
@@ -1,0 +1,1 @@
+Placeholder for Gang Of Three font (.woff2)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,13 @@
-@import 'https://fonts.cdnfonts.com/css/gang-of-three';
+/* @import 'https://fonts.cdnfonts.com/css/gang-of-three'; */
 @import "tailwindcss";
-@import 'https://fonts.cdnfonts.com/css/gang-of-three';
+/* @import 'https://fonts.cdnfonts.com/css/gang-of-three'; */
+
+@font-face {
+  font-family: 'Gang of Three';
+  src: url('/fonts/GangOfThree.woff2') format('woff2'),
+       url('/fonts/GangOfThree.ttf') format('truetype');
+  font-display: swap;
+}
 
 :root {
   --background: #ffffff;


### PR DESCRIPTION
## Summary
- add placeholder Gang of Three fonts under `public/fonts`
- comment remote `@import` statement
- define `@font-face` rule for Gang of Three

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4bce234c8327b8e0fc059ad26e99